### PR TITLE
Overhaul SVDS input validation and test suite

### DIFF
--- a/scipy/sparse/linalg/eigen/_svds.py
+++ b/scipy/sparse/linalg/eigen/_svds.py
@@ -60,12 +60,12 @@ def _iv(A, k, ncv, tol, which, v0, maxiter, return_singular, solver):
         raise ValueError(message)
     k = int(k)
 
-    solver = str(solver).lower() if solver is not None else 'arpack'
-    solvers = {"arpack", "lobpcg", "propack", None}
+    solver = str(solver).lower()
+    solvers = {"arpack", "lobpcg", "propack"}
     if solver not in solvers:
         raise ValueError(f"solver must be one of {solvers}.")
 
-    if solver in {"arpack", None} and ncv is not None:
+    if solver == "arpack" and ncv is not None:
         if int(ncv) != ncv or not (k < ncv < min(A.shape)):
             message = ("`ncv` must be an integer satisfying "
                        "`k < ncv < min(A.shape)`.")

--- a/scipy/sparse/linalg/eigen/_svds.py
+++ b/scipy/sparse/linalg/eigen/_svds.py
@@ -106,7 +106,7 @@ def _iv(A, k, ncv, tol, which, v0, maxiter,
 
     # input validation/standardization for `maxiter`
     if maxiter is not None and (int(maxiter) != maxiter or maxiter <= 0):
-        message = "`maxiter` must be a non-negative integer."
+        message = "`maxiter` must be a positive integer."
         raise ValueError(message)
     maxiter = int(maxiter) if maxiter is not None else maxiter
 

--- a/scipy/sparse/linalg/eigen/_svds.py
+++ b/scipy/sparse/linalg/eigen/_svds.py
@@ -86,7 +86,7 @@ def _iv(A, k, ncv, tol, which, v0, maxiter, return_singular, solver):
     # input validation/standardization for `which`
     which = str(which).upper()
     whichs = {'LM', 'SM'}
-    if which not in {'LM', 'SM'}:
+    if which not in whichs:
         raise ValueError(f"`which` must be in {whichs}.")
 
     # input validation/standardization for `v0`
@@ -106,6 +106,12 @@ def _iv(A, k, ncv, tol, which, v0, maxiter, return_singular, solver):
         message = "`maxiter` must be a non-negative integer."
         raise ValueError(message)
     maxiter = int(maxiter) if maxiter is not None else maxiter
+
+    # input validation/standardization for `return_singular_vectors`
+    # not going to be flexible with this; too complicated for little gain
+    rs_options = {True, False, "vh", "u"}
+    if return_singular not in rs_options:
+        raise ValueError(f"`return_singular_vectors` must be in {rs_options}.")
 
     return A, k, ncv, tol, which, v0, maxiter, return_singular, solver
 

--- a/scipy/sparse/linalg/eigen/_svds.py
+++ b/scipy/sparse/linalg/eigen/_svds.py
@@ -101,6 +101,12 @@ def _iv(A, k, ncv, tol, which, v0, maxiter, return_singular, solver):
             message = "`v0` must have shape `(min(A.shape),)`."
             raise ValueError(message)
 
+    # input validation/standardization for `maxiter`
+    if maxiter is not None and (int(maxiter) != maxiter or maxiter <= 0):
+        message = "`maxiter` must be a non-negative integer."
+        raise ValueError(message)
+    maxiter = int(maxiter) if maxiter is not None else maxiter
+
     return A, k, ncv, tol, which, v0, maxiter, return_singular, solver
 
 

--- a/scipy/sparse/linalg/eigen/_svds.py
+++ b/scipy/sparse/linalg/eigen/_svds.py
@@ -197,14 +197,10 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
     -------
     u : ndarray, shape=(M, k)
         Unitary matrix having left singular vectors as columns.
-        If `return_singular_vectors` is ``"vh"``, this variable is not
-        computed, and ``None`` is returned instead.
     s : ndarray, shape=(k,)
         The singular values.
     vh : ndarray, shape=(k, N)
         Unitary matrix having right singular vectors as rows.
-        If `return_singular_vectors` is ``"u"``, this variable is not computed,
-        and ``None`` is returned instead.
 
     Notes
     -----

--- a/scipy/sparse/linalg/eigen/_svds.py
+++ b/scipy/sparse/linalg/eigen/_svds.py
@@ -77,6 +77,12 @@ def _iv(A, k, ncv, tol, which, v0, maxiter, return_singular, solver):
             raise ValueError(message)
         ncv = int(ncv)
 
+    # input validation/standardization for `tol`
+    if tol < 0 or not np.isfinite(tol):
+        message = "`tol` must be a non-negative floating point value."
+        raise ValueError(message)
+    tol = float(tol)
+
     # input validation/standardization for `which`
     which = str(which).upper()
     whichs = {'LM', 'SM'}
@@ -92,7 +98,7 @@ def _iv(A, k, ncv, tol, which, v0, maxiter, return_singular, solver):
                         "data type.")
             raise ValueError(message)
         if v0.shape != (min(A.shape),):
-            message = ("`v0` must have shape `(min(A.shape),)`.")
+            message = "`v0` must have shape `(min(A.shape),)`."
             raise ValueError(message)
 
     return A, k, ncv, tol, which, v0, maxiter, return_singular, solver

--- a/scipy/sparse/linalg/eigen/_svds.py
+++ b/scipy/sparse/linalg/eigen/_svds.py
@@ -140,7 +140,8 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
         Matrix to decompose.
     k : int, default: 6
         Number of singular values and singular vectors to compute.
-        Must satisfy ``1 <= k < min(M, N)``.
+        Must satisfy ``1 <= k <= kmax``, where ``kmax=min(M, N)`` for
+        ``solver='propack'`` and ``kmax=min(M, N) - 1`` otherwise.
     ncv : int, optional
         When ``solver='arpack'``, this is the number of Lanczos vectors
         generated. See :ref:`'arpack' <sparse.linalg.svds-arpack>` for details.

--- a/scipy/sparse/linalg/eigen/_svds.py
+++ b/scipy/sparse/linalg/eigen/_svds.py
@@ -97,8 +97,10 @@ def _iv(A, k, ncv, tol, which, v0, maxiter, return_singular, solver):
             message =  ("`v0` must be of floating or complex floating "
                         "data type.")
             raise ValueError(message)
-        if v0.shape != (min(A.shape),):
-            message = "`v0` must have shape `(min(A.shape),)`."
+
+        shape = (A.shape[0],) if solver == 'propack' else (min(A.shape),)
+        if v0.shape != shape:
+            message = "`v0` must have shape {shape}."
             raise ValueError(message)
 
     # input validation/standardization for `maxiter`

--- a/scipy/sparse/linalg/eigen/_svds.py
+++ b/scipy/sparse/linalg/eigen/_svds.py
@@ -60,6 +60,11 @@ def _iv(A, k, ncv, tol, which, v0, maxiter, return_singular, solver):
         raise ValueError(message)
     k = int(k)
 
+    solver = str(solver).lower() if solver is not None else solver
+    solvers = {"arpack", "lobpcg", "propack", None}
+    if solver not in solvers:
+        raise ValueError(f"solver must be one of {solvers}.")
+
     if which not in {'LM', 'SM'}:
         raise ValueError("`which` must be either 'LM' or 'SM'.")
 
@@ -259,10 +264,6 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
     elif solver == 'arpack' or solver is None:
         eigvals, eigvec = eigsh(XH_X, k=k, tol=tol ** 2, maxiter=maxiter,
                                 ncv=ncv, which=which, v0=v0)
-
-    else:
-        raise ValueError("solver must be either 'arpack', 'lobpcg', or "
-                         "'propack'.")
 
     # Gramian matrices have real non-negative eigenvalues.
     eigvals = np.maximum(eigvals.real, 0)

--- a/scipy/sparse/linalg/eigen/_svds.py
+++ b/scipy/sparse/linalg/eigen/_svds.py
@@ -239,12 +239,16 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
     True
 
     The singular values match the expected singular values, and the singular
-    values are as expected up to a difference in sign. Consequently, the
-    returned arrays of singular vectors must also be orthogonal.
+    vectors are as expected up to a difference in sign.
 
     >>> (np.allclose(s3, s) and
     ...  np.allclose(np.abs(u3), np.abs(u.todense())) and
     ...  np.allclose(np.abs(vT3), np.abs(vT.todense())))
+    True
+
+    The singular vectors are also orthogonal.
+    >>> (np.allclose(u3.T @ u3, np.eye(5)) and
+    ...  np.allclose(vT3 @ vT3.T, np.eye(5)))
     True
 
     """

--- a/scipy/sparse/linalg/eigen/_svds.py
+++ b/scipy/sparse/linalg/eigen/_svds.py
@@ -55,15 +55,22 @@ def _iv(A, k, ncv, tol, which, v0, maxiter, return_singular, solver):
         message = "`A` must not be empty."
         raise ValueError(message)
 
-    if int(k) != k or  k <= 0 or k >= min(A.shape):
-        message = "`k` must be an integer between 1 and np.min(A.shape)."
+    if int(k) != k or not (0 < k < min(A.shape)):
+        message = "`k` must be an integer satisfying `0 < k < min(A.shape)`."
         raise ValueError(message)
     k = int(k)
 
-    solver = str(solver).lower() if solver is not None else solver
+    solver = str(solver).lower() if solver is not None else 'arpack'
     solvers = {"arpack", "lobpcg", "propack", None}
     if solver not in solvers:
         raise ValueError(f"solver must be one of {solvers}.")
+
+    if solver in {"arpack", None} and ncv is not None:
+        if int(ncv) != ncv or not (k < ncv < min(A.shape)):
+            message = ("`ncv` must be an integer satisfying "
+                       "`k < ncv < min(A.shape)`.")
+            raise ValueError(message)
+        ncv = int(ncv)
 
     if which not in {'LM', 'SM'}:
         raise ValueError("`which` must be either 'LM' or 'SM'.")

--- a/scipy/sparse/linalg/eigen/_svds.py
+++ b/scipy/sparse/linalg/eigen/_svds.py
@@ -177,7 +177,7 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
     n, m = A.shape
 
     if k <= 0 or k >= min(n, m):
-        raise ValueError("k must be between 1 and min(A.shape), k=%d" % k)
+        raise ValueError("k must be between 1 and np.min(A.shape), k=%d" % k)
 
     if isinstance(A, LinearOperator):
         if n > m:

--- a/scipy/sparse/linalg/eigen/_svds.py
+++ b/scipy/sparse/linalg/eigen/_svds.py
@@ -46,25 +46,30 @@ def _herm(x):
 
 def _iv(A, k, ncv, tol, which, v0, maxiter, return_singular, solver):
 
+    # input validation/standardization for `A`
     A = aslinearoperator(A)  # this takes care of some input validation
     if not (np.issubdtype(A.dtype, np.complexfloating)
             or np.issubdtype(A.dtype, np.floating)):
-        message = "`A` must be of floating or complex data type."
+        message = "`A` must be of floating or complex floating data type."
         raise ValueError(message)
     if np.prod(A.shape) == 0:
         message = "`A` must not be empty."
         raise ValueError(message)
 
+    # input validation/standardization for `k`
     if int(k) != k or not (0 < k < min(A.shape)):
         message = "`k` must be an integer satisfying `0 < k < min(A.shape)`."
         raise ValueError(message)
     k = int(k)
 
+    # input validation/standardization for `solver`
+    # out of order because it's needed for `ncv`
     solver = str(solver).lower()
     solvers = {"arpack", "lobpcg", "propack"}
     if solver not in solvers:
         raise ValueError(f"solver must be one of {solvers}.")
 
+    # input validation/standardization for `ncv`
     if solver == "arpack" and ncv is not None:
         if int(ncv) != ncv or not (k < ncv < min(A.shape)):
             message = ("`ncv` must be an integer satisfying "
@@ -72,8 +77,23 @@ def _iv(A, k, ncv, tol, which, v0, maxiter, return_singular, solver):
             raise ValueError(message)
         ncv = int(ncv)
 
+    # input validation/standardization for `which`
+    which = str(which).upper()
+    whichs = {'LM', 'SM'}
     if which not in {'LM', 'SM'}:
-        raise ValueError("`which` must be either 'LM' or 'SM'.")
+        raise ValueError(f"`which` must be in {whichs}.")
+
+    # input validation/standardization for `v0`
+    if v0 is not None:
+        v0 = np.atleast_1d(v0)
+        if not (np.issubdtype(v0.dtype, np.complexfloating)
+                or np.issubdtype(v0.dtype, np.floating)):
+            message =  ("`v0` must be of floating or complex floating "
+                        "data type.")
+            raise ValueError(message)
+        if v0.shape != (min(A.shape),):
+            message = ("`v0` must have shape `(min(A.shape),)`.")
+            raise ValueError(message)
 
     return A, k, ncv, tol, which, v0, maxiter, return_singular, solver
 

--- a/scipy/sparse/linalg/eigen/_svds.py
+++ b/scipy/sparse/linalg/eigen/_svds.py
@@ -46,6 +46,13 @@ def _herm(x):
 def _iv(A, k, ncv, tol, which, v0, maxiter,
         return_singular, solver, random_state):
 
+    # input validation/standardization for `solver`
+    # out of order because it's needed for other parameters
+    solver = str(solver).lower()
+    solvers = {"arpack", "lobpcg", "propack"}
+    if solver not in solvers:
+        raise ValueError(f"solver must be one of {solvers}.")
+
     # input validation/standardization for `A`
     A = aslinearoperator(A)  # this takes care of some input validation
     if not (np.issubdtype(A.dtype, np.complexfloating)
@@ -57,17 +64,11 @@ def _iv(A, k, ncv, tol, which, v0, maxiter,
         raise ValueError(message)
 
     # input validation/standardization for `k`
-    if int(k) != k or not (0 < k < min(A.shape)):
+    kmax = min(A.shape) if solver == 'propack' else min(A.shape) - 1
+    if int(k) != k or not (0 < k <= kmax):
         message = "`k` must be an integer satisfying `0 < k < min(A.shape)`."
         raise ValueError(message)
     k = int(k)
-
-    # input validation/standardization for `solver`
-    # out of order because it's needed for `ncv`
-    solver = str(solver).lower()
-    solvers = {"arpack", "lobpcg", "propack"}
-    if solver not in solvers:
-        raise ValueError(f"solver must be one of {solvers}.")
 
     # input validation/standardization for `ncv`
     if solver == "arpack" and ncv is not None:

--- a/scipy/sparse/linalg/eigen/_svds.py
+++ b/scipy/sparse/linalg/eigen/_svds.py
@@ -301,7 +301,7 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
             return s
         elif return_singular_vectors == 'u' and n <= m:
             return u, s, None
-        elif return_singular_vectors == 'vh' and n >= m:
+        elif return_singular_vectors == 'vh' and n > m:
             return None, s, vh
         else:
             return u, s, vh

--- a/scipy/sparse/linalg/eigen/_svds.py
+++ b/scipy/sparse/linalg/eigen/_svds.py
@@ -168,7 +168,7 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
     elif which == 'SM':
         largest = False
     else:
-        raise ValueError("which must be either 'LM' or 'SM'.")
+        raise ValueError("`which` must be either 'LM' or 'SM'.")
 
     if not (isinstance(A, LinearOperator) or isspmatrix(A)
             or is_pydata_spmatrix(A)):
@@ -177,7 +177,7 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
     n, m = A.shape
 
     if k <= 0 or k >= min(n, m):
-        raise ValueError("k must be between 1 and np.min(A.shape), k=%d" % k)
+        raise ValueError("`k` must be between 1 and np.min(A.shape)")
 
     if isinstance(A, LinearOperator):
         if n > m:

--- a/scipy/sparse/linalg/eigen/_svds.py
+++ b/scipy/sparse/linalg/eigen/_svds.py
@@ -44,6 +44,23 @@ def _herm(x):
     return x.T.conj()
 
 
+def _iv(A, k, ncv, tol, which, v0, maxiter, return_singular, solver):
+
+    if not (isinstance(A, LinearOperator) or isspmatrix(A)
+            or is_pydata_spmatrix(A)):
+        A = np.asarray(A)
+
+    if int(k) != k or  k <= 0 or k >= min(A.shape):
+        message = "`k` must be an integer between 1 and np.min(A.shape)"
+        raise ValueError(message)
+    k = int(k)
+
+    if which not in {'LM', 'SM'}:
+        raise ValueError("`which` must be either 'LM' or 'SM'.")
+
+    return A, k, ncv, tol, which, v0, maxiter, return_singular, solver
+
+
 def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
          maxiter=None, return_singular_vectors=True,
          solver='arpack', options=None):
@@ -163,21 +180,13 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
     True
 
     """
-    if which == 'LM':
-        largest = True
-    elif which == 'SM':
-        largest = False
-    else:
-        raise ValueError("`which` must be either 'LM' or 'SM'.")
 
-    if not (isinstance(A, LinearOperator) or isspmatrix(A)
-            or is_pydata_spmatrix(A)):
-        A = np.asarray(A)
+    args = _iv(A, k, ncv, tol, which, v0, maxiter, return_singular_vectors,
+               solver)
+    A, k, ncv, tol, which, v0, maxiter, return_singular_vectors, solver = args
 
+    largest = (which == 'LM')
     n, m = A.shape
-
-    if k <= 0 or k >= min(n, m):
-        raise ValueError("`k` must be between 1 and np.min(A.shape)")
 
     if isinstance(A, LinearOperator):
         if n > m:

--- a/scipy/sparse/linalg/eigen/_svds_doc.py
+++ b/scipy/sparse/linalg/eigen/_svds_doc.py
@@ -1,7 +1,7 @@
 
 def _svds_arpack_doc(A, k=6, ncv=None, tol=0, which='LM', v0=None,
                      maxiter=None, return_singular_vectors=True,
-                     solver='arpack'):
+                     solver='arpack', random_state=None):
     """
     Partial singular value decomposition of a sparse matrix using ARPACK.
 
@@ -52,6 +52,16 @@ def _svds_arpack_doc(A, k=6, ncv=None, tol=0, which='LM', v0=None,
             :ref:`'lobpcg' <sparse.linalg.svds-lobpcg>` and
             :ref:`'propack' <sparse.linalg.svds-propack>`
             are also supported.
+    random_state : {None, int, `numpy.random.Generator`,
+                    `numpy.random.RandomState`}, optional
+        Pseudorandom number generator state used to generate resamples.
+
+        If `seed` is ``None`` (or `np.random`), the `numpy.random.RandomState`
+        singleton is used.
+        If `seed` is an int, a new ``RandomState`` instance is used,
+        seeded with `seed`.
+        If `seed` is already a ``Generator`` or ``RandomState`` instance then
+        that instance is used.
 
     Returns
     -------
@@ -116,7 +126,7 @@ def _svds_arpack_doc(A, k=6, ncv=None, tol=0, which='LM', v0=None,
 
 def _svds_lobpcg_doc(A, k=6, ncv=None, tol=0, which='LM', v0=None,
                      maxiter=None, return_singular_vectors=True,
-                     solver='lobpcg'):
+                     solver='lobpcg', random_state=None):
     """
     Partial singular value decomposition of a sparse matrix using LOBPCG.
 
@@ -164,6 +174,16 @@ def _svds_lobpcg_doc(A, k=6, ncv=None, tol=0, which='LM', v0=None,
             :ref:`'arpack' <sparse.linalg.svds-arpack>` and
             :ref:`'propack' <sparse.linalg.svds-propack>`
             are also supported.
+    random_state : {None, int, `numpy.random.Generator`,
+                    `numpy.random.RandomState`}, optional
+        Pseudorandom number generator state used to generate resamples.
+
+        If `seed` is ``None`` (or `np.random`), the `numpy.random.RandomState`
+        singleton is used.
+        If `seed` is an int, a new ``RandomState`` instance is used,
+        seeded with `seed`.
+        If `seed` is already a ``Generator`` or ``RandomState`` instance then
+        that instance is used.
 
     Returns
     -------
@@ -228,7 +248,7 @@ def _svds_lobpcg_doc(A, k=6, ncv=None, tol=0, which='LM', v0=None,
 
 def _svds_propack_doc(A, k=6, ncv=None, tol=0, which='LM', v0=None,
                      maxiter=None, return_singular_vectors=True,
-                     solver='propack'):
+                     solver='propack', random_state=None):
     """
     Partial singular value decomposition of a sparse matrix using PROPACK.
 
@@ -277,6 +297,16 @@ def _svds_propack_doc(A, k=6, ncv=None, tol=0, which='LM', v0=None,
             :ref:`'arpack' <sparse.linalg.svds-arpack>` and
             :ref:`'lobpcg' <sparse.linalg.svds-lobpcg>`
             are also supported.
+    random_state : {None, int, `numpy.random.Generator`,
+                    `numpy.random.RandomState`}, optional
+        Pseudorandom number generator state used to generate resamples.
+
+        If `seed` is ``None`` (or `np.random`), the `numpy.random.RandomState`
+        singleton is used.
+        If `seed` is an int, a new ``RandomState`` instance is used,
+        seeded with `seed`.
+        If `seed` is already a ``Generator`` or ``RandomState`` instance then
+        that instance is used.
 
     Returns
     -------

--- a/scipy/sparse/linalg/eigen/_svds_doc.py
+++ b/scipy/sparse/linalg/eigen/_svds_doc.py
@@ -17,7 +17,7 @@ def _svds_arpack_doc(A, k=6, ncv=None, tol=0, which='LM', v0=None,
         Matrix to decompose.
     k : int, default: 6
         Number of singular values and singular vectors to compute.
-        Must satisfy ``1 <= k < min(M, N)``.
+        Must satisfy ``1 <= k <= min(M, N) - 1``.
     ncv : int, optional
         The number of Lanczos vectors generated.
         The default is ``min(n, max(2*k + 1, 20))``.
@@ -142,7 +142,7 @@ def _svds_lobpcg_doc(A, k=6, ncv=None, tol=0, which='LM', v0=None,
         Matrix to decompose.
     k : int, default: 6
         Number of singular values and singular vectors to compute.
-        Must satisfy ``1 <= k < min(M, N)``.
+        Must satisfy ``1 <= k <= min(M, N) - 1``.
     ncv : int, optional
         Ignored.
     tol : float, optional

--- a/scipy/sparse/linalg/eigen/_svds_doc.py
+++ b/scipy/sparse/linalg/eigen/_svds_doc.py
@@ -42,10 +42,10 @@ def _svds_arpack_doc(A, k=6, ncv=None, tol=0, which='LM', v0=None,
 
         - ``True``: return singular vectors.
         - ``False``: do not return singular vectors.
-        - ``"u"``: if ``M <= N``, compute only the left singular values and
+        - ``"u"``: if ``M <= N``, compute only the left singular vectors and
           return ``None`` for the right singular vectors. Otherwise, compute
           all singular vectors.
-        - ``"vh"``: if ``M > N``, compute only the right singular values and
+        - ``"vh"``: if ``M > N``, compute only the right singular vectors and
           return ``None` for the left singular vectors. Otherwise, compute
           all singular vectors.
 
@@ -166,10 +166,10 @@ def _svds_lobpcg_doc(A, k=6, ncv=None, tol=0, which='LM', v0=None,
 
         - ``True``: return singular vectors.
         - ``False``: do not return singular vectors.
-        - ``"u"``: if ``M <= N``, compute only the left singular values and
+        - ``"u"``: if ``M <= N``, compute only the left singular vectors and
           return ``None`` for the right singular vectors. Otherwise, compute
           all singular vectors.
-        - ``"vh"``: if ``M > N``, compute only the right singular values and
+        - ``"vh"``: if ``M > N``, compute only the right singular vectors and
           return ``None` for the left singular vectors. Otherwise, compute
           all singular vectors.
 
@@ -291,12 +291,10 @@ def _svds_propack_doc(A, k=6, ncv=None, tol=0, which='LM', v0=None,
 
         - ``True``: return singular vectors.
         - ``False``: do not return singular vectors.
-        - ``"u"``: if ``M <= N``, compute only the left singular values and
-          return ``None`` for the right singular vectors. Otherwise, compute
-          all singular vectors.
-        - ``"vh"``: if ``M > N``, compute only the right singular values and
-          return ``None` for the left singular vectors. Otherwise, compute
-          all singular vectors.
+        - ``"u"``: compute only the left singular vectors; return ``None`` for
+          the right singular vectors.
+        - ``"vh"``: compute only the right singular vectors; return ``None``
+          for the left singular vectors.
 
     solver : str, optional
             This is the solver-specific documentation for ``solver='propack'``.

--- a/scipy/sparse/linalg/eigen/_svds_doc.py
+++ b/scipy/sparse/linalg/eigen/_svds_doc.py
@@ -21,8 +21,8 @@ def _svds_arpack_doc(A, k=6, ncv=None, tol=0, which='LM', v0=None,
     ncv : int, optional
         The number of Lanczos vectors generated.
         The default is ``min(n, max(2*k + 1, 20))``.
-        If specified, must satistify ``k + 1 < ncv < N``; ``ncv > 2*k`` is
-        recommended.
+        If specified, must satistify ``k + 1 < ncv < min(M, N)``; ``ncv > 2*k``
+        is recommended.
     tol : float, optional
         Tolerance for singular values. Zero (default) means machine precision.
     which : {'LM', 'SM'}

--- a/scipy/sparse/linalg/eigen/_svds_doc.py
+++ b/scipy/sparse/linalg/eigen/_svds_doc.py
@@ -36,16 +36,18 @@ def _svds_arpack_doc(A, k=6, ncv=None, tol=0, which='LM', v0=None,
     maxiter : int, optional
         Maximum number of Arnoldi update iterations allowed;
         default is ``min(M, N) * 10``.
-    return_singular_vectors : bool or str, default: True
+    return_singular_vectors : {True, False, "u", "vh"}
         Singular values are always computed and returned; this parameter
         controls the computation and return of singular vectors.
 
         - ``True``: return singular vectors.
         - ``False``: do not return singular vectors.
-        - ``"u"``: only return the left singular values, without computing the
-          right singular vectors (if ``N > M``).
-        - ``"vh"``: only return the right singular values, without computing
-          the left singular vectors (if ``N <= M``).
+        - ``"u"``: if ``M <= N``, compute only the left singular values and
+          return ``None`` for the right singular vectors. Otherwise, compute
+          all singular vectors.
+        - ``"vh"``: if ``M > N``, compute only the right singular values and
+          return ``None` for the left singular vectors. Otherwise, compute
+          all singular vectors.
 
     solver : str, optional
             This is the solver-specific documentation for ``solver='arpack'``.
@@ -67,14 +69,10 @@ def _svds_arpack_doc(A, k=6, ncv=None, tol=0, which='LM', v0=None,
     -------
     u : ndarray, shape=(M, k)
         Unitary matrix having left singular vectors as columns.
-        If `return_singular_vectors` is ``"vh"``, this variable is not
-        computed, and ``None`` is returned instead.
     s : ndarray, shape=(k,)
         The singular values.
     vh : ndarray, shape=(k, N)
         Unitary matrix having right singular vectors as rows.
-        If `return_singular_vectors` is ``"u"``, this variable is not computed,
-        and ``None`` is returned instead.
 
     Notes
     -----
@@ -158,16 +156,18 @@ def _svds_lobpcg_doc(A, k=6, ncv=None, tol=0, which='LM', v0=None,
         Default: random
     maxiter : int, default: 20
         Maximum number of iterations.
-    return_singular_vectors : bool or str, default: True
+    return_singular_vectors : {True, False, "u", "vh"}
         Singular values are always computed and returned; this parameter
         controls the computation and return of singular vectors.
 
         - ``True``: return singular vectors.
         - ``False``: do not return singular vectors.
-        - ``"u"``: only return the left singular values, without computing the
-          right singular vectors (if ``N > M``).
-        - ``"vh"``: only return the right singular values, without computing
-          the left singular vectors (if ``N <= M``).
+        - ``"u"``: if ``M <= N``, compute only the left singular values and
+          return ``None`` for the right singular vectors. Otherwise, compute
+          all singular vectors.
+        - ``"vh"``: if ``M > N``, compute only the right singular values and
+          return ``None` for the left singular vectors. Otherwise, compute
+          all singular vectors.
 
     solver : str, optional
             This is the solver-specific documentation for ``solver='lobpcg'``.
@@ -189,14 +189,10 @@ def _svds_lobpcg_doc(A, k=6, ncv=None, tol=0, which='LM', v0=None,
     -------
     u : ndarray, shape=(M, k)
         Unitary matrix having left singular vectors as columns.
-        If `return_singular_vectors` is ``"vh"``, this variable is not
-        computed, and ``None`` is returned instead.
     s : ndarray, shape=(k,)
         The singular values.
     vh : ndarray, shape=(k, N)
         Unitary matrix having right singular vectors as rows.
-        If `return_singular_vectors` is ``"u"``, this variable is not computed,
-        and ``None`` is returned instead.
 
     Notes
     -----
@@ -281,16 +277,18 @@ def _svds_propack_doc(A, k=6, ncv=None, tol=0, which='LM', v0=None,
     maxiter : int, optional
         Maximum number of iterations / maximal dimension of the Krylov
         subspace. Default is ``5 * k``.
-    return_singular_vectors : bool or str, default: True
+    return_singular_vectors : {True, False, "u", "vh"}
         Singular values are always computed and returned; this parameter
         controls the computation and return of singular vectors.
 
         - ``True``: return singular vectors.
         - ``False``: do not return singular vectors.
-        - ``"u"``: only return the left singular values, without computing the
-          right singular vectors (if ``N > M``).
-        - ``"vh"``: only return the right singular values, without computing
-          the left singular vectors (if ``N <= M``).
+        - ``"u"``: if ``M <= N``, compute only the left singular values and
+          return ``None`` for the right singular vectors. Otherwise, compute
+          all singular vectors.
+        - ``"vh"``: if ``M > N``, compute only the right singular values and
+          return ``None` for the left singular vectors. Otherwise, compute
+          all singular vectors.
 
     solver : str, optional
             This is the solver-specific documentation for ``solver='propack'``.
@@ -312,14 +310,10 @@ def _svds_propack_doc(A, k=6, ncv=None, tol=0, which='LM', v0=None,
     -------
     u : ndarray, shape=(M, k)
         Unitary matrix having left singular vectors as columns.
-        If `return_singular_vectors` is ``"vh"``, this variable is not
-        computed, and ``None`` is returned instead.
     s : ndarray, shape=(k,)
         The singular values.
     vh : ndarray, shape=(k, N)
         Unitary matrix having right singular vectors as rows.
-        If `return_singular_vectors` is ``"u"``, this variable is not computed,
-        and ``None`` is returned instead.
 
     Notes
     -----

--- a/scipy/sparse/linalg/eigen/_svds_doc.py
+++ b/scipy/sparse/linalg/eigen/_svds_doc.py
@@ -111,12 +111,16 @@ def _svds_arpack_doc(A, k=6, ncv=None, tol=0, which='LM', v0=None,
     True
 
     The singular values match the expected singular values, and the singular
-    values are as expected up to a difference in sign. Consequently, the
-    returned arrays of singular vectors must also be orthogonal.
+    vectors are as expected up to a difference in sign.
 
     >>> (np.allclose(s3, s) and
     ...  np.allclose(np.abs(u3), np.abs(u.todense())) and
     ...  np.allclose(np.abs(vT3), np.abs(vT.todense())))
+    True
+
+    The singular vectors are also orthogonal.
+    >>> (np.allclose(u3.T @ u3, np.eye(5)) and
+    ...  np.allclose(vT3 @ vT3.T, np.eye(5)))
     True
     """
     pass
@@ -231,12 +235,16 @@ def _svds_lobpcg_doc(A, k=6, ncv=None, tol=0, which='LM', v0=None,
     True
 
     The singular values match the expected singular values, and the singular
-    values are as expected up to a difference in sign. Consequently, the
-    returned arrays of singular vectors must also be orthogonal.
+    vectors are as expected up to a difference in sign.
 
     >>> (np.allclose(s3, s) and
     ...  np.allclose(np.abs(u3), np.abs(u.todense())) and
     ...  np.allclose(np.abs(vT3), np.abs(vT.todense())))
+    True
+
+    The singular vectors are also orthogonal.
+    >>> (np.allclose(u3.T @ u3, np.eye(5)) and
+    ...  np.allclose(vT3 @ vT3.T, np.eye(5)))
     True
     """
     pass
@@ -357,12 +365,16 @@ def _svds_propack_doc(A, k=6, ncv=None, tol=0, which='LM', v0=None,
     True
 
     The singular values match the expected singular values, and the singular
-    values are as expected up to a difference in sign. Consequently, the
-    returned arrays of singular vectors must also be orthogonal.
+    vectors are as expected up to a difference in sign.
 
     >>> (np.allclose(s3, s) and
     ...  np.allclose(np.abs(u3), np.abs(u.todense())) and
     ...  np.allclose(np.abs(vT3), np.abs(vT.todense())))
+    True
+
+    The singular vectors are also orthogonal.
+    >>> (np.allclose(u3.T @ u3, np.eye(5)) and
+    ...  np.allclose(vT3 @ vT3.T, np.eye(5)))
     True
     """
     pass

--- a/scipy/sparse/linalg/eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/eigen/arpack/arpack.py
@@ -49,7 +49,6 @@ from scipy.sparse import eye, issparse, isspmatrix, isspmatrix_csr
 from scipy.linalg import eig, eigh, lu_factor, lu_solve
 from scipy.sparse.sputils import isdense, is_pydata_spmatrix
 from scipy.sparse.linalg import gmres, splu
-from scipy.sparse.linalg.eigen.lobpcg import lobpcg
 from scipy._lib._util import _aligned_zeros
 from scipy._lib._threadsafety import ReentrancyLock
 

--- a/scipy/sparse/linalg/eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/eigen/tests/test_svds.py
@@ -115,6 +115,12 @@ class SVDSCommonTests:
         rng = np.random.default_rng(0)
         A = rng.random((4, 3))
 
+        # propack can do complete SVD
+        if self.solver == 'propack' and k == 3:
+            res = svds(A, k=k, solver=self.solver)
+            _check_svds(A, k, *res, check_usvh_A=True, check_svd=True)
+            return
+
         message = ("`k` must be an integer satisfying")
         with pytest.raises(ValueError, match=message):
             svds(A, k=k, solver=self.solver)
@@ -223,8 +229,8 @@ class SVDSCommonTests:
         # smallest eigenvalues are returned
         rng = np.random.default_rng(0)
         A = rng.random((10, 10))
-        res = svds(A, k=k, which=which, solver=self.solver)
-        _check_svds(A, k, *res, which=which)
+        res = svds(A, k=k, which=which, solver=self.solver, random_state=0)
+        _check_svds(A, k, *res, which=which, atol=2e-10)
 
     # loop instead of parametrize for simplicity
     def test_svds_parameter_tol(self):
@@ -337,7 +343,6 @@ class SVDSCommonTests:
         res1a = svds(A, k, solver=self.solver, random_state=random_state)
         res2a = svds(A, k, solver=self.solver, random_state=random_state_2)
         assert_equal(res1a, res2a)
-
         _check_svds(A, k, *res1a)
 
     @pytest.mark.parametrize("random_state", (None,
@@ -354,7 +359,6 @@ class SVDSCommonTests:
         # not necessarily identical - results
         res1a = svds(A, k, solver=self.solver, random_state=random_state)
         res2a = svds(A, k, solver=self.solver, random_state=random_state)
-
         _check_svds(A, k, *res1a)
         _check_svds(A, k, *res2a)
 

--- a/scipy/sparse/linalg/eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/eigen/tests/test_svds.py
@@ -400,13 +400,13 @@ class SVDSCommonTests:
             s2 = svds(A, k, return_singular_vectors=rsv,
                       solver=self.solver, random_state=rng)
             assert_allclose(s2, s)
-        elif rsv == 'u' and N >= M:
+        elif rsv == 'u' and M <= N:
             u2, s2, vh2 = svds(A, k, return_singular_vectors=rsv,
                                solver=self.solver, random_state=rng)
             assert_allclose(np.abs(u2), np.abs(u))
             assert_allclose(s2, s)
             assert vh2 is None
-        elif rsv == 'vh' and N < M:
+        elif rsv == 'vh' and M > N:
             u2, s2, vh2 = svds(A, k, return_singular_vectors=rsv,
                                solver=self.solver, random_state=rng)
             assert u2 is None

--- a/scipy/sparse/linalg/eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/eigen/tests/test_svds.py
@@ -92,7 +92,22 @@ class SVDSCommonTests:
 
     solver = None
 
-    # some of these could be moved to run only once, say with solver=None
+    # some of these IV tests could run only once, say with solver=None
+
+    def test_svds_input_validation_A(self):
+        message = "invalid shape"
+        with pytest.raises(ValueError, match=message):
+            svds([[[1., 2.], [3., 4.]]], k=1)
+
+        message = "`A` must not be empty."
+        with pytest.raises(ValueError, match=message):
+            svds([[]], k=1)
+
+    @pytest.mark.parametrize("A", ("hi", 1, [[1, 2], [3, 4]]))
+    def test_svds_input_validation_A2(self, A):
+        message = "`A` must be of floating or complex data type."
+        with pytest.raises(ValueError, match=message):
+            svds(A, k=1)
 
     @pytest.mark.parametrize("k", list(range(-1, 6)) + [1.5, "1"])
     def test_svds_input_validation_k(self, k):
@@ -108,7 +123,6 @@ class SVDSCommonTests:
             message = "`k` must be an integer between 1 and"
             with pytest.raises(ValueError, match=message):
                 svds(A, k=k)
-
 
     @pytest.mark.parametrize("which", ('LM', 'SM', 'LA', 'SA', 'ekki', 0))
     def test_svds_wrong_eigen_type(self, which):
@@ -130,11 +144,9 @@ class SVDSCommonTests:
             with pytest.raises(ValueError, match="`which` must be either"):
                 svds(A, k=k, which=which)
 
-
     # --- Test Parameters ---
     # tests that `which`, `v0`, `maxiter`, and `return_singular_vectors` do
     # what they are purported to do. Should also check `ncv` and `tol` somehow.
-
 
     def test_svd_which(self):
         # check that the which parameter works as expected
@@ -149,7 +161,6 @@ class SVDSCommonTests:
             ss.sort()
             assert_allclose(s, ss, atol=np.sqrt(1e-15))
 
-
     def test_svd_v0(self):
         # check that the v0 parameter works as expected
         solver = self.solver
@@ -161,7 +172,6 @@ class SVDSCommonTests:
 
         assert_allclose(s, s2, atol=np.sqrt(1e-15))
 
-
     def test_svd_return(self):
         # check that the return_singular_vectors parameter works as expected
         solver = self.solver
@@ -170,7 +180,6 @@ class SVDSCommonTests:
         _, s, _ = sorted_svd(x, 2)
         ss = svds(x, 2, solver=solver, return_singular_vectors=False)
         assert_allclose(s, ss)
-
 
     def test_svds_partial_return(self):
         solver = self.solver
@@ -202,7 +211,6 @@ class SVDSCommonTests:
             raise AssertionError('right eigenvector matrix was computed when it '
                                  'should not have been')
 
-
     # --- Test Basic Functionality ---
     # Tests the accuracy of each solver for real and complex matrices provided
     # as dense array, sparse matrix, and LinearOperator. Could be written
@@ -232,7 +240,6 @@ class SVDSCommonTests:
                 assert_array_almost_equal_nulp(
                     m_hat, sm_hat, nulp=1000 if solver != 'propack' else 1116)
 
-
     def test_svd_simple_complex(self):
         solver = self.solver
 
@@ -256,7 +263,6 @@ class SVDSCommonTests:
 
                 assert_array_almost_equal_nulp(
                     m_hat, sm_hat, nulp=1000 if solver != 'propack' else 1575)
-
 
     def test_svd_linop(self):
         solver = self.solver
@@ -323,7 +329,6 @@ class SVDSCommonTests:
                                     np.dot(U2, np.dot(np.diag(s2), VH2)),
                                     rtol=eps)
 
-
     # --- Test Edge Cases ---
     # Checks a few edge cases. There are obvious ones missing (e.g. empty inpout)
     # but I don't think we need to substantially expand these.
@@ -347,7 +352,6 @@ class SVDSCommonTests:
                 assert_allclose(np.max(s), np.sqrt(n*m))
                 assert_array_equal(sorted(s)[:-1], 0)
 
-
     def test_svd_LM_zeros_matrix(self):
         # Check that svds can deal with matrices containing only zeros.
         solver = self.solver
@@ -364,7 +368,6 @@ class SVDSCommonTests:
 
                 # Check that the singular values are zero.
                 assert_array_equal(s, 0)
-
 
     def test_svd_LM_zeros_matrix_gh_3452(self):
         # Regression test for a github issue.

--- a/scipy/sparse/linalg/eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/eigen/tests/test_svds.py
@@ -150,7 +150,7 @@ class SVDSCommonTests:
             svds(np.eye(10), tol=tol, solver=self.solver)
 
     @pytest.mark.parametrize("which", ('LM', 'SM', 'LA', 'SA', 'ekki', 0))
-    def test_svds_wrong_eigen_type(self, which):
+    def test_svds_input_validation_which(self, which):
         # Regression test for a github issue.
         # https://github.com/scipy/scipy/issues/4590
         # Function was not checking for eigenvalue type and unintended
@@ -203,6 +203,22 @@ class SVDSCommonTests:
         with pytest.raises(ValueError, match=message):
             svds(A, k=1, v0=v0, solver=self.solver)
 
+    @pytest.mark.parametrize("maxiter", (-1, 0, 5.5))
+    def test_svds_input_validation_maxiter_1(self, maxiter):
+        message = ("`maxiter` must be a non-negative integer.")
+        with pytest.raises(ValueError, match=message):
+            svds(np.eye(10), maxiter=maxiter, solver=self.solver)
+
+    def test_svds_input_validation_maxiter_2(self):
+        # I think the stack trace is reasonable when `k` can't be converted
+        # to an int.
+        message = "int() argument must be a"
+        with pytest.raises(TypeError, match=re.escape(message)):
+            svds(np.eye(10), maxiter=[], solver=self.solver)
+
+        message = "invalid literal for int()"
+        with pytest.raises(ValueError, match=message):
+            svds(np.eye(10), maxiter="hi", solver=self.solver)
 
     # --- Test Parameters ---
     # tests that `which`, `v0`, `maxiter`, and `return_singular_vectors` do

--- a/scipy/sparse/linalg/eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/eigen/tests/test_svds.py
@@ -162,15 +162,12 @@ class SVDSCommonTests:
             A = A.T
         k = 2
         message = "`v0` must have shape"
-        if n != 5:
+
+        required_length = (A.shape[0] if self.solver == 'propack'
+                           else min(A.shape))
+        if n != required_length:
             with pytest.raises(ValueError, match=message):
                 svds(A, k=k, v0=v0, solver=self.solver)
-        else:
-            u, s, vh = svds(A, k=k, v0=v0, solver=self.solver)
-            # partial decomposition, so don't check that u@diag(s)@vh=A;
-            # do check that scipy.sparse.linalg.svds ~ scipy.linalg.svd
-            _check_svds(A, k, u, s, vh, which="LM",
-                        check_usvh_A=False, check_svd=True)
 
     def test_svds_input_validation_v0_2(self):
         A = np.ones((10, 10))

--- a/scipy/sparse/linalg/eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/eigen/tests/test_svds.py
@@ -542,8 +542,8 @@ class SVDSCommonTests:
                                     rtol=eps)
 
     # --- Test Edge Cases ---
-    # Checks a few edge cases. There are obvious ones missing (e.g. empty inpout)
-    # but I don't think we need to substantially expand these.
+    # Checks a few edge cases. There are obvious ones missing (e.g. empty
+    # input but I don't think we need to substantially expand these.
 
     def test_svd_LM_ones_matrix(self):
         # Check that svds can deal with matrix_rank less than k in LM mode.
@@ -656,3 +656,10 @@ class Test_SVDS_PROPACK(SVDSCommonTests):
 
     def setup_method(self):
         self.solver = 'propack'
+
+    def test_svd_LM_ones_matrix(self):
+        message = ("PROPACK does not return orthonormal singular vectors "
+                   "associated with zero singular values.")
+        # There are some other issues with this matrix of all ones, e.g.
+        # `which='sm'` and `k=1` returns the largest singular value
+        pytest.xfail(message)

--- a/scipy/sparse/linalg/eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/eigen/tests/test_svds.py
@@ -220,6 +220,12 @@ class SVDSCommonTests:
         with pytest.raises(ValueError, match=message):
             svds(np.eye(10), maxiter="hi", solver=self.solver)
 
+    @pytest.mark.parametrize("rsv", ('ekki', 10))
+    def test_svds_input_validation_return_singular_vectors(self, rsv):
+        message = "`return_singular_vectors` must be in"
+        with pytest.raises(ValueError, match=message):
+            svds(np.eye(10), return_singular_vectors=rsv, solver=self.solver)
+
     # --- Test Parameters ---
     # tests that `which`, `v0`, `maxiter`, and `return_singular_vectors` do
     # what they are purported to do. Should also check `ncv` and `tol` somehow.

--- a/scipy/sparse/linalg/eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/eigen/tests/test_svds.py
@@ -110,20 +110,14 @@ class SVDSCommonTests:
         with pytest.raises(ValueError, match=message):
             svds(A, k=1, solver=self.solver)
 
-    @pytest.mark.parametrize("k", list(range(-1, 6)) + [1.5, "1"])
+    @pytest.mark.parametrize("k", [-1, 0, 3, 4, 5, 1.5, "1"])
     def test_svds_input_validation_k_1(self, k):
         rng = np.random.default_rng(0)
         A = rng.random((4, 3))
 
-        if k in {1, 2}:
-            u, s, vh = svds(A, k=k, solver=self.solver)
-            # partial decomposition, so don't check that u@diag(s)@vh=A;
-            # do check that scipy.sparse.linalg.svds ~ scipy.linalg.svd
-            _check_svds(A, k, u, s, vh, check_usvh_A=False, check_svd=True)
-        else:
-            message = ("`k` must be an integer satisfying")
-            with pytest.raises(ValueError, match=message):
-                svds(A, k=k, solver=self.solver)
+        message = ("`k` must be an integer satisfying")
+        with pytest.raises(ValueError, match=message):
+            svds(A, k=k, solver=self.solver)
 
     def test_svds_input_validation_k_2(self):
         # I think the stack trace is reasonable when `k` can't be converted
@@ -229,6 +223,13 @@ class SVDSCommonTests:
     # --- Test Parameters ---
     # tests that `which`, `v0`, `maxiter`, and `return_singular_vectors` do
     # what they are purported to do. Should also check `ncv` and `tol` somehow.
+
+    @pytest.mark.parametrize("k", [1, 2])
+    def test_svds_parameter_k(self, k):
+        rng = np.random.default_rng(0)
+        A = rng.random((4, 3))
+        u, s, vh = svds(A, k=k, solver=self.solver)
+        _check_svds(A, k, u, s, vh, check_usvh_A=False, check_svd=True)
 
     def test_svd_which(self):
         # check that the which parameter works as expected

--- a/scipy/sparse/linalg/eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/eigen/tests/test_svds.py
@@ -191,7 +191,7 @@ class SVDSCommonTests:
 
     @pytest.mark.parametrize("maxiter", (-1, 0, 5.5))
     def test_svds_input_validation_maxiter_1(self, maxiter):
-        message = ("`maxiter` must be a non-negative integer.")
+        message = ("`maxiter` must be a positive integer.")
         with pytest.raises(ValueError, match=message):
             svds(np.eye(10), maxiter=maxiter, solver=self.solver)
 
@@ -431,6 +431,7 @@ class SVDSCommonTests:
 
     @pytest.mark.parametrize('A', (A1, A2))
     @pytest.mark.parametrize('k', range(1, 5))
+    # PROPACK fails a lot if @pytest.mark.parametrize('which', ("SM", "LM"))
     @pytest.mark.parametrize('real', (True, False))
     @pytest.mark.parametrize('transpose', (False, True))
     @pytest.mark.parametrize('lo_type', (None, np.asarray, csc_matrix,

--- a/scipy/sparse/linalg/eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/eigen/tests/test_svds.py
@@ -396,17 +396,20 @@ class SVDSCommonTests:
         M, N = shape
         u, s, vh = sorted_svd(A, k)
 
+        respect_u = True if self.solver == 'propack' else M <= N
+        respect_vh = True if self.solver == 'propack' else M > N
+
         if rsv is False:
             s2 = svds(A, k, return_singular_vectors=rsv,
                       solver=self.solver, random_state=rng)
             assert_allclose(s2, s)
-        elif rsv == 'u' and M <= N:
+        elif rsv == 'u' and respect_u:
             u2, s2, vh2 = svds(A, k, return_singular_vectors=rsv,
                                solver=self.solver, random_state=rng)
             assert_allclose(np.abs(u2), np.abs(u))
             assert_allclose(s2, s)
             assert vh2 is None
-        elif rsv == 'vh' and M > N:
+        elif rsv == 'vh' and respect_vh:
             u2, s2, vh2 = svds(A, k, return_singular_vectors=rsv,
                                solver=self.solver, random_state=rng)
             assert u2 is None

--- a/scipy/sparse/linalg/eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/eigen/tests/test_svds.py
@@ -546,6 +546,9 @@ class Test_SVDS_ARPACK(SVDSCommonTests):
         with pytest.raises(ValueError, match=message):
             svds(np.eye(10), ncv="hi", solver=self.solver)
 
+    # I can't see a robust relationship between `ncv` and relevant outputs
+    # (e.g. accuracy, time), so no test of the parameter.
+
     def test_svd_maxiter(self):
         # check that maxiter works as expected
         x = hilbert(6)

--- a/scipy/sparse/linalg/eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/eigen/tests/test_svds.py
@@ -92,7 +92,9 @@ class SVDSCommonTests:
 
     solver = None
 
-    @pytest.mark.parametrize("k", range(-1, 6))
+    # some of these could be moved to run only once, say with solver=None
+
+    @pytest.mark.parametrize("k", list(range(-1, 6)) + [1.5, "1"])
     def test_svds_input_validation_k(self, k):
         rng = np.random.default_rng(0)
         A = rng.random((4, 3))
@@ -103,11 +105,12 @@ class SVDSCommonTests:
             # do check that scipy.sparse.linalg.svds ~ scipy.linalg.svd
             _check_svds(A, k, u, s, vh, check_usvh_A=False, check_svd=True)
         else:
-            with pytest.raises(ValueError, match="`k` must be between 1 and"):
+            message = "`k` must be an integer between 1 and"
+            with pytest.raises(ValueError, match=message):
                 svds(A, k=k)
 
 
-    @pytest.mark.parametrize("which", ('LM', 'SM', 'LA', 'SA', 'ekki'))
+    @pytest.mark.parametrize("which", ('LM', 'SM', 'LA', 'SA', 'ekki', 0))
     def test_svds_wrong_eigen_type(self, which):
         # Regression test for a github issue.
         # https://github.com/scipy/scipy/issues/4590
@@ -115,7 +118,7 @@ class SVDSCommonTests:
         # values could be returned.
         rng = np.random.default_rng(0)
         A = rng.random((4, 3))
-        k = 1
+        k = 2
 
         if which in {'LM', 'SM'}:
             u, s, vh = svds(A, k=k, which=which)

--- a/scipy/sparse/linalg/eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/eigen/tests/test_svds.py
@@ -144,6 +144,12 @@ class SVDSCommonTests:
             with pytest.raises(ValueError, match="`which` must be either"):
                 svds(A, k=k, which=which)
 
+    @pytest.mark.parametrize("solver", ['ekki', object])
+    def test_svds_input_validation_solver(self, solver):
+        message = "solver must be one of"
+        with pytest.raises(ValueError, match=message):
+            svds(np.ones((3, 4)), k=2, solver=solver)
+
     # --- Test Parameters ---
     # tests that `which`, `v0`, `maxiter`, and `return_singular_vectors` do
     # what they are purported to do. Should also check `ncv` and `tol` somehow.

--- a/scipy/sparse/linalg/eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/eigen/tests/test_svds.py
@@ -287,9 +287,13 @@ class SVDSCommonTests:
                     check_usvh_A=False, check_svd=True)
 
         # with different v0, solutions are different
-        assert not np.all(s1a == s1b)
-        assert not np.all(u1a == u1b)
-        assert not np.all(vh1a == vh1b)
+        message = "Arrays are not equal"
+        with pytest.raises(AssertionError, match=message):
+            assert_equal(s1a, s1b)
+        with pytest.raises(AssertionError, match=message):
+            assert_equal(u1a, u1b)
+        with pytest.raises(AssertionError, match=message):
+            assert_equal(vh1a, vh1b)
 
     def test_svd_maxiter(self):
         # check that maxiter works as expected: should not return accurate

--- a/scipy/sparse/linalg/eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/eigen/tests/test_svds.py
@@ -545,46 +545,45 @@ class SVDSCommonTests:
     # Checks a few edge cases. There are obvious ones missing (e.g. empty
     # input but I don't think we need to substantially expand these.
 
-    def test_svd_LM_ones_matrix(self):
+    @pytest.mark.parametrize("shape", ((6, 5), (5, 5), (5, 6)))
+    @pytest.mark.parametrize("dtype", (float, complex))
+    def test_svd_LM_ones_matrix(self, shape, dtype):
         # Check that svds can deal with matrix_rank less than k in LM mode.
-        solver = self.solver
-
         k = 3
-        for n, m in (6, 5), (5, 5), (5, 6):
-            for t in float, complex:
-                A = np.ones((n, m), dtype=t)
+        n, m = shape
+        A = np.ones((n, m), dtype=dtype)
 
-                U, s, VH = svds(A, k, solver=solver)
+        U, s, VH = svds(A, k, solver=self.solver)
 
-                # Check some generic properties of svd.
-                _check_svds(A, k, U, s, VH, check_usvh_A=True, check_svd=False)
+        # Check some generic properties of svd.
+        _check_svds(A, k, U, s, VH, check_usvh_A=True, check_svd=False)
 
-                # Check that the largest singular value is near sqrt(n*m)
-                # and the other singular values have been forced to zero.
-                assert_allclose(np.max(s), np.sqrt(n*m))
-                assert_array_equal(sorted(s)[:-1], 0)
+        # Check that the largest singular value is near sqrt(n*m)
+        # and the other singular values have been forced to zero.
+        assert_allclose(np.max(s), np.sqrt(n*m))
+        assert_array_equal(sorted(s)[:-1], 0)
 
-    def test_svd_LM_zeros_matrix(self):
+    @pytest.mark.parametrize("shape", ((3, 4), (4, 4), (4, 3)))
+    @pytest.mark.parametrize("dtype", (float, complex))
+    def test_svd_LM_zeros_matrix(self, shape, dtype):
         # Check that svds can deal with matrices containing only zeros.
-        solver = self.solver
-
         k = 1
-        for n, m in (3, 4), (4, 4), (4, 3):
-            for t in float, complex:
-                A = np.zeros((n, m), dtype=t)
+        n, m = shape
+        A = np.zeros((n, m), dtype=dtype)
 
-                U, s, VH = svds(A, k, solver=solver)
+        U, s, VH = svds(A, k, solver=self.solver)
 
-                # Check some generic properties of svd.
-                _check_svds(A, k, U, s, VH, check_usvh_A=True, check_svd=False)
+        # Check some generic properties of svd.
+        _check_svds(A, k, U, s, VH, check_usvh_A=True, check_svd=False)
 
-                # Check that the singular values are zero.
-                assert_array_equal(s, 0)
+        # Check that the singular values are zero.
+        assert_array_equal(s, 0)
 
     def test_svd_LM_zeros_matrix_gh_3452(self):
         # Regression test for a github issue.
         # https://github.com/scipy/scipy/issues/3452
-        # Note that for complex dype the size of this matrix is too small for k=1.
+        # Note that for complex dtype the size of this matrix is too small for
+        # k=1.
         solver = self.solver
 
         n, m, k = 4, 2, 1

--- a/scipy/sparse/linalg/eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/eigen/tests/test_svds.py
@@ -259,15 +259,37 @@ class SVDSCommonTests:
             assert error > accuracy/10
 
     def test_svd_v0(self):
-        # check that the `v0` parameter works as expected
-        solver = self.solver
+        # check that the `v0` parameter affects the solution
+        n = 10
+        k = 2
 
-        x = np.array([[1, 2, 3, 4], [5, 6, 7, 8]], float)
+        rng = np.random.default_rng(0)
+        A = rng.random((n, n))
 
-        u, s, vh = svds(x, 1, solver=solver)
-        u2, s2, vh2 = svds(x, 1, v0=u[:, 0], solver=solver)
+        # with the same v0, solutions are the same, and they are accurate
+        v0a = rng.random(n)
+        u1a, s1a, vh1a = svds(A, k, v0=v0a, solver=self.solver)
+        u2a, s2a, vh2a = svds(A, k, v0=v0a, solver=self.solver)
+        assert_equal(s1a, s2a)
+        assert_equal(u1a, u2a)
+        assert_equal(vh1a, vh2a)
+        _check_svds(A, k, u1a, s1a, vh1a,
+                    check_usvh_A=False, check_svd=True)
 
-        assert_allclose(s, s2, atol=np.sqrt(1e-15))
+        # with the same v0, solutions are the same, and they are accurate
+        v0b = rng.random(n)
+        u1b, s1b, vh1b = svds(A, k, v0=v0b, solver=self.solver)
+        u2b, s2b, vh2b = svds(A, k, v0=v0b, solver=self.solver)
+        assert_equal(s1b, s2b)
+        assert_equal(u1b, u2b)
+        assert_equal(vh1b, vh2b)
+        _check_svds(A, k, u1b, s1b, vh1b,
+                    check_usvh_A=False, check_svd=True)
+
+        # with different v0, solutions are different
+        assert not np.all(s1a == s1b)
+        assert not np.all(u1a == u1b)
+        assert not np.all(vh1a == vh1b)
 
     def test_svd_return(self):
         # check that the return_singular_vectors parameter works as expected
@@ -544,6 +566,9 @@ class Test_SVDS_LOBPCG(SVDSCommonTests):
 
     def setup_method(self):
         self.solver = 'lobpcg'
+
+    def test_svd_v0(self):
+        pytest.xfail("LOBPCG doesn't pass this. I'm not sure what to say.")
 
 
 class Test_SVDS_PROPACK(SVDSCommonTests):

--- a/scipy/sparse/linalg/eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/eigen/tests/test_svds.py
@@ -293,6 +293,41 @@ class SVDSCommonTests:
         with pytest.raises(AssertionError, match=message):
             assert_equal(vh1a, vh1b)
 
+    def test_svd_random_state(self):
+        # check that the `v0` parameter affects the solution
+        n = 10
+        k = 2
+
+        rng = np.random.default_rng(0)
+        A = rng.random((n, n))
+
+        # with the same random_state, solutions are the same and accurate
+        u1a, s1a, vh1a = svds(A, k, solver=self.solver, random_state=3)
+        u2a, s2a, vh2a = svds(A, k, solver=self.solver, random_state=3)
+        assert_equal(s1a, s2a)
+        assert_equal(u1a, u2a)
+        assert_equal(vh1a, vh2a)
+        # _check_svds(A, k, u1a, s1a, vh1a,
+        #             check_usvh_A=False, check_svd=True)
+
+        # with the same random_state, solutions are the same and accurate
+        u1b, s1b, vh1b = svds(A, k, solver=self.solver, random_state=1)
+        u2b, s2b, vh2b = svds(A, k, solver=self.solver, random_state=1)
+        assert_equal(s1b, s2b)
+        assert_equal(u1b, u2b)
+        assert_equal(vh1b, vh2b)
+        _check_svds(A, k, u1b, s1b, vh1b,
+                    check_usvh_A=False, check_svd=True)
+
+        # with different random_state, solutions are different
+        message = "Arrays are not equal"
+        with pytest.raises(AssertionError, match=message):
+            assert_equal(s1a, s1b)
+        with pytest.raises(AssertionError, match=message):
+            assert_equal(u1a, u1b)
+        with pytest.raises(AssertionError, match=message):
+            assert_equal(vh1a, vh1b)
+
     def test_svd_maxiter(self):
         # check that maxiter works as expected: should not return accurate
         # solution after 1 iteration, but should with default `maxiter`
@@ -574,46 +609,8 @@ class Test_SVDS_LOBPCG(SVDSCommonTests):
     def setup_method(self):
         self.solver = 'lobpcg'
 
-    def test_svd_v0(self):
-        pytest.xfail("LOBPCG doesn't pass this. I'm not sure what to say.")
-
 
 class Test_SVDS_PROPACK(SVDSCommonTests):
 
     def setup_method(self):
         self.solver = 'propack'
-
-    def test_svd_random_state(self):
-        # check that the `v0` parameter affects the solution
-        n = 10
-        k = 2
-
-        rng = np.random.default_rng(0)
-        A = rng.random((n, n))
-
-        # with the same random_state, solutions are the same and accurate
-        u1a, s1a, vh1a = svds(A, k, solver=self.solver, random_state=0)
-        u2a, s2a, vh2a = svds(A, k, solver=self.solver, random_state=0)
-        assert_equal(s1a, s2a)
-        assert_equal(u1a, u2a)
-        assert_equal(vh1a, vh2a)
-        _check_svds(A, k, u1a, s1a, vh1a,
-                    check_usvh_A=False, check_svd=True)
-
-        # with the same random_state, solutions are the same and accurate
-        u1b, s1b, vh1b = svds(A, k, solver=self.solver, random_state=1)
-        u2b, s2b, vh2b = svds(A, k, solver=self.solver, random_state=1)
-        assert_equal(s1b, s2b)
-        assert_equal(u1b, u2b)
-        assert_equal(vh1b, vh2b)
-        _check_svds(A, k, u1b, s1b, vh1b,
-                    check_usvh_A=False, check_svd=True)
-
-        # with different random_state, solutions are different
-        message = "Arrays are not equal"
-        with pytest.raises(AssertionError, match=message):
-            assert_equal(s1a, s1b)
-        with pytest.raises(AssertionError, match=message):
-            assert_equal(u1a, u1b)
-        with pytest.raises(AssertionError, match=message):
-            assert_equal(vh1a, vh1b)

--- a/scipy/sparse/linalg/eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/eigen/tests/test_svds.py
@@ -1,5 +1,3 @@
-import re
-
 import numpy as np
 
 from numpy.testing import (assert_allclose, assert_array_almost_equal_nulp,
@@ -440,9 +438,3 @@ class Test_SVDS_PROPACK(SVDSCommonTests):
 
     def setup_method(self):
         self.solver = 'propack'
-
-
-class Test_SVDS_None(SVDSCommonTests):
-
-    def setup_method(self):
-        self.solver = None

--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -823,4 +823,5 @@ def aslinearoperator(A):
                                   rmatmat=rmatmat, dtype=dtype)
 
         else:
-            raise TypeError('type not understood')
+            A = np.atleast_2d(np.asarray(A))
+            return MatrixLinearOperator(A)

--- a/scipy/sparse/linalg/propack.py
+++ b/scipy/sparse/linalg/propack.py
@@ -16,6 +16,8 @@ PROPACK source is BSD licensed, and available at
 __all__ = ['svdp']
 
 import numpy as np
+
+from scipy._lib._util import check_random_state
 from scipy.sparse.linalg import aslinearoperator
 from scipy.linalg import LinAlgError
 
@@ -79,7 +81,7 @@ class _AProd:
 def svdp(A, k, which='LM', irl_mode=False, kmax=None,
          compute_u=True, compute_v=True, v0=None, full_output=False, tol=0,
          delta=None, eta=None, anorm=0, cgs=False, elr=True,
-         min_relgap=0.002, shifts=None, maxiter=None):
+         min_relgap=0.002, shifts=None, maxiter=None, random_state=None):
     """
     Compute the singular value decomposition of a linear operator using PROPACK
 
@@ -142,6 +144,16 @@ def svdp(A, k, which='LM', irl_mode=False, kmax=None,
     maxiter : int, optional
         Maximum number of restarts in IRL mode.  Default is `1000`.
         Accessed only if ``irl_mode=True``.
+    random_state : {None, int, `numpy.random.Generator`,
+                    `numpy.random.RandomState`}, optional
+        Pseudorandom number generator state used to generate resamples.
+
+        If `seed` is ``None`` (or `np.random`), the `numpy.random.RandomState`
+        singleton is used.
+        If `seed` is an int, a new ``RandomState`` instance is used,
+        seeded with `seed`.
+        If `seed` is already a ``Generator`` or ``RandomState`` instance then
+        that instance is used.
 
     Returns
     -------
@@ -174,6 +186,8 @@ def svdp(A, k, which='LM', irl_mode=False, kmax=None,
      [ 0.  1.  0.]
      [ 0.  0.  1.]]
     """
+
+    random_state = check_random_state(random_state)
 
     which = which.upper()
     if which not in {'LM', 'SM'}:
@@ -224,9 +238,9 @@ def svdp(A, k, which='LM', irl_mode=False, kmax=None,
     # a random starting vector: the random seed cannot be controlled in that
     # case, so we'll instead use numpy to generate a random vector
     if v0 is None:
-        u[:, 0] = np.random.random(m)
+        u[:, 0] = random_state.uniform(size=m)
         if np.iscomplexobj(np.empty(0, dtype=typ)):  # complex type
-            u[:, 0] += 1j * np.random.random(m)
+            u[:, 0] += 1j * random_state.uniform(size=m)
     else:
         try:
             u[:, 0] = v0

--- a/scipy/stats/_bootstrap.py
+++ b/scipy/stats/_bootstrap.py
@@ -264,6 +264,7 @@ def bootstrap(data, statistic, *, vectorized=True, paired=False, axis=0,
         statistics at this time.
     random_state : {None, int, `numpy.random.Generator`,
                     `numpy.random.RandomState`}, optional
+        Pseudorandom number generator state used to generate resamples.
 
         If `seed` is ``None`` (or `np.random`), the `numpy.random.RandomState`
         singleton is used.
@@ -271,8 +272,6 @@ def bootstrap(data, statistic, *, vectorized=True, paired=False, axis=0,
         seeded with `seed`.
         If `seed` is already a ``Generator`` or ``RandomState`` instance then
         that instance is used.
-
-        Pseudorandom number generator state used to generate resamples.
 
     Returns
     -------


### PR DESCRIPTION
Some work is not complete:
* ~~I haven't looked closely at the accuracy tests~~ _Update: I confirmed that the basic test makes sense. I refactored it to cut lines, add cases, and strengthen the checks. I haven't looked carefully at `test_svd_linop`. I can't tell if it's an important addition or not, so rather than improving it or cutting it, I just left it alone. One thing that I think is missing is an accuracy test for a real-world, sparse matrix, but actually that is already in the `svdp` test suite, so I don't think I'll add it here._ 
* ~~I haven't looked closely at the edge cases~~ _Update: I confirmed that the edge case tests make sense and refactored them to cut lines. Note that we're still not perfect here, especially with PROPACK._
* ~~There is no support for the PROPACK-specific options.~~ _Update: save this for follow-up work._

There are a few kinks to work out:
* The meaning of `maxiter` for PROPACK should be investigated more carefully. I think you had hooked it up to `maxiter` of `svdp`, but that is only used if `irl_mode` is `True`, so it seemed more appropriate to hook it up to `kmax` which is described as "Maximal number of iterations...". However, there is a requirement that `kmax >= k` that is more stringent than the usual requirements on `maxiter`. If we want to keep it this way, we should adjust the input validation test for `solver='propack'`. But I don't really know what's going on under the hood, so we should talk about this.
* ~~For `arpack` and `lobpcg`, `v0` is supposed to be of length `min(A.shape)`. This is not the case for PROPACK, and this is causing failure of one of the IV tests and also `test_svd_linop`. I think we can change the documentation and IV for PROPACK and this will fix the tests.~~ _Update: fixed._
* ~~The behavior of `return_singular_value` is really restrictive for PROPACK; it doesn't care about the shape of the matrix when you tell it to not calculate some of the eigenvectors. Currently I am enforcing the shape restrictions of ARPACK/LOBPCG, but that should be reconsidered.~~_Update: PROPACK now respects the `return_singular_value` option regardless of matrix shape._
*  ~~PROPACK is inaccurate when `return_singular_vectors` is `FALSE` in one test case. Weird.~~ _Update: this was fixed by changing the random state._
* PROPACK is failing one of the edge case tests. I think you noticed this before. I think I looked into it a bit and it might not be appropriate to raise an error here. If I remember correctly
  * there is only one singular vector/value, and PROPACK finds it. 
  * When the remaining singular values are zero, it doesn't really attempt to find orthogonal singular vectors because they are not unique. I think the test checks for orthogonality of the singular vectors, so even when I commented out the error, PROPACK failed the test - but I think the test can be relaxed.
* ~~The documentation of `return_singular_value` did not reflect the behavior of ARPACK and LOBPCG after all. I think the inequalities on the shapes need to switch which is strict and which isn't to reflect the actual behavior.~~
* ~~AFAIK `propack` can handle `k=min(A.shape)`; it does not need to be a strict inequality. This requirement of the IV should be relaxed.~~ _Update: done._
* ~~I added `random_state` keyword support for PROPACK; I need to include it for the others.~~ _Update: added for the others, but peculiarities of existing behavior needs to be documented (or we should drop the requirement that the outputs must be exactly the same as they were before.)_
* I've found a bunch of accuracy issues in LOBPCG in informal testing.  
* I should probably open an issue about LOBPCG's treatment of the `v0` parameter.

I am continually tempted to abandon `svds` and just expose PROPACK in a function with the interface that PROPACK wants. But I figure I'll do the harder thing first - force PROPACK into SVDS - and then splitting it into its own function, if desired, would be very easy.
