### PR TITLE
MAINT: sparse.linalg: svds should NOT work with lists of lists

### DIFF
--- a/scipy/sparse/linalg/eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/eigen/tests/test_svds.py
@@ -95,25 +95,19 @@ class SVDSCommonTests:
 
     # some of these IV tests could run only once, say with solver=None
 
-    def test_svds_input_validation_A(self):
-        A = np.asarray([[]])
-        message = "`A` must not be empty."
-        with pytest.raises(ValueError, match=message):
-            svds(A, k=1, solver=self.solver)
-
-        A = np.asarray([[1, 2], [3, 4]])
-        message = "`A` must be of floating or complex floating data type."
-        with pytest.raises(ValueError, match=message):
-            svds(A, k=1, solver=self.solver)
-
-        A = "hi"
-        message = "type not understood"
-        with pytest.raises(TypeError, match=message):
-            svds(A, k=1, solver=self.solver)
-
-        A = np.asarray([[[1., 2.], [3., 4.]]])
-        message = "array must have ndim <= 2"
-        with pytest.raises(ValueError, match=message):
+    _A_empty_msg = "`A` must not be empty."
+    _A_dtype_msg = "`A` must be of floating or complex floating data type"
+    _A_type_msg = "type not understood"
+    _A_ndim_msg = "array must have ndim <= 2"
+    _A_validation_inputs =[
+        (np.asarray([[]]), ValueError, _A_empty_msg),
+        (np.asarray([[1, 2], [3, 4]]), ValueError, _A_dtype_msg),
+        ("hi", TypeError, _A_type_msg),
+        (np.asarray([[[1., 2.], [3., 4.]]]), ValueError, _A_ndim_msg)]
+    @pytest.mark.parametrize("args", _A_validation_inputs)
+    def test_svds_input_validation_A(self, args):
+        A, error_type, message = args
+        with pytest.raises(error_type, match=message):
             svds(A, k=1, solver=self.solver)
 
     @pytest.mark.parametrize("k", [-1, 0, 3, 4, 5, 1.5, "1"])

--- a/scipy/sparse/linalg/interface.py
+++ b/scipy/sparse/linalg/interface.py
@@ -823,5 +823,4 @@ def aslinearoperator(A):
                                   rmatmat=rmatmat, dtype=dtype)
 
         else:
-            A = np.atleast_2d(np.asarray(A))
-            return MatrixLinearOperator(A)
+            raise TypeError('type not understood')


### PR DESCRIPTION
#### Reference issue
gh-14299

#### What does this implement/fix?
In gh-14299, I suggested making `svds` work with lists of lists.  I was told to leave it alone. This PR undoes some changes that made `svds` work with lists of lists and reworks the associated tests.