### PR TITLE
Use `irl_mode=False` when possible

### DIFF
--- a/scipy/sparse/linalg/_svdp.py
+++ b/scipy/sparse/linalg/_svdp.py
@@ -106,7 +106,7 @@ def _svdp(A, k, which='LM', irl_mode=True, kmax=None,
         mode.  Default is `True`.
     kmax : int, optional
         Maximal number of iterations / maximal dimension of the Krylov
-        subspace. Default is ``5 * k``.
+        subspace. Default is ``10 * k``.
     compute_u : bool, optional
         If `True` (default) then compute left singular vectors, `u`.
     compute_v : bool, optional
@@ -222,7 +222,7 @@ def _svdp(A, k, which='LM', irl_mode=True, kmax=None,
         raise ValueError("k must be positive and not greater than m or n")
 
     if kmax is None:
-        kmax = 5*k
+        kmax = 10*k
     if maxiter is None:
         maxiter = 1000
 

--- a/scipy/sparse/linalg/eigen/_svds.py
+++ b/scipy/sparse/linalg/eigen/_svds.py
@@ -312,8 +312,9 @@ def svds(A, k=6, ncv=None, tol=0, which='LM', v0=None,
     elif solver == 'propack':
         jobu = return_singular_vectors in {True, 'u'}
         jobv = return_singular_vectors in {True, 'vh'}
+        irl_mode = (which == 'SM')
         res = _svdp(A, k=k, tol=tol**2, which=which, maxiter=None,
-                    compute_u=jobu, compute_v=jobv, irl_mode=True,
+                    compute_u=jobu, compute_v=jobv, irl_mode=irl_mode,
                     kmax=maxiter, v0=v0, random_state=random_state)
 
         u, s, vh, _ = res  # but we'll ignore bnd, the last output

--- a/scipy/sparse/linalg/eigen/_svds_doc.py
+++ b/scipy/sparse/linalg/eigen/_svds_doc.py
@@ -286,7 +286,7 @@ def _svds_propack_doc(A, k=6, ncv=None, tol=0, which='LM', v0=None,
         If not specified, PROPACK will generate a starting vector.
     maxiter : int, optional
         Maximum number of iterations / maximal dimension of the Krylov
-        subspace. Default is ``5 * k``.
+        subspace. Default is ``10 * k``.
     return_singular_vectors : {True, False, "u", "vh"}
         Singular values are always computed and returned; this parameter
         controls the computation and return of singular vectors.

--- a/scipy/sparse/linalg/eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/eigen/tests/test_svds.py
@@ -257,7 +257,7 @@ class SVDSCommonTests:
 
         tols = [1e-4, 1e-2, 1e0]  # tolerance levels to check
         # for 'arpack' and 'propack', accuracies make discrete steps
-        accuracies = {'propack': [1e-14, 1e-13, 1e-5],
+        accuracies = {'propack': [1e-12, 1e-6, 1e-4],
                       'arpack': [1e-15, 1e-10, 1e-10],
                       'lobpcg': [1e-11, 1e-3, 10]}
 
@@ -359,8 +359,8 @@ class SVDSCommonTests:
         # not necessarily identical - results
         res1a = svds(A, k, solver=self.solver, random_state=random_state)
         res2a = svds(A, k, solver=self.solver, random_state=random_state)
-        _check_svds(A, k, *res1a)
-        _check_svds(A, k, *res2a)
+        _check_svds(A, k, *res1a, rtol=1e-6)
+        _check_svds(A, k, *res2a, rtol=1e-6)
 
         message = "Arrays are not equal"
         with pytest.raises(AssertionError, match=message):
@@ -377,11 +377,15 @@ class SVDSCommonTests:
             message = "ARPACK error -1: No convergence"
             with pytest.raises(ArpackNoConvergence, match=message):
                 svds(A, k, ncv=3, maxiter=1, solver=self.solver)
-        else:
+        elif self.solver == 'lobpcg':
             message = "Not equal to tolerance"
             with pytest.raises(AssertionError, match=message):
                 u2, s2, vh2 = svds(A, k, maxiter=1, solver=self.solver)
                 assert_allclose(np.abs(u2), np.abs(u))
+        elif self.solver == 'propack':
+            message = "k=1 singular triplets did not converge within"
+            with pytest.raises(np.linalg.LinAlgError, match=message):
+                svds(A, k, maxiter=1, solver=self.solver)
 
         u, s, vh = svds(A, k, solver=self.solver)  # default maxiter
         _check_svds(A, k, u, s, vh)

--- a/scipy/sparse/linalg/tests/test_propack.py
+++ b/scipy/sparse/linalg/tests/test_propack.py
@@ -254,9 +254,9 @@ def test_shifts(shifts, precision):
     A = np.random.random((n, n))
     if shifts is not None and ((shifts < 0) or (k > min(n-1-shifts, n))):
         with pytest.raises(ValueError):
-            _svdp(A, k, shifts=shifts, irl_mode=True)
+            _svdp(A, k, shifts=shifts, kmax=5*k, irl_mode=True)
     else:
-        _svdp(A, k, shifts=shifts, irl_mode=True)
+        _svdp(A, k, shifts=shifts, kmax=5*k, irl_mode=True)
 
 
 @pytest.mark.slow


### PR DESCRIPTION
Please check if the changes to tests look reasonable and if the changes to `kmax`, `irl_mode` look complete.