### PR TITLE
ENH: optimize: linprog: make `integrality` a parameter

### DIFF
--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -620,6 +620,7 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
         warn(warning_message, OptimizeWarning)
 
     if integrality and not meth == "highs":
+        integrality = None
         warning_message = ("Only `method='highs'` supports integer "
                            "constraints. Ignoring `integrality`.")
         warn(warning_message, OptimizeWarning)

--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -168,7 +168,7 @@ def linprog_terse_callback(res):
 
 def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
             bounds=None, method='interior-point', callback=None,
-            options=None, x0=None):
+            options=None, x0=None, integrality=None):
     r"""
     Linear programming: minimize a linear objective function subject to linear
     equality and inequality constraints.
@@ -337,6 +337,22 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
         'revised simplex' method, and can only be used if `x0` represents a
         basic feasible solution.
 
+    integrality : 1-D array, optional
+        Indicates the type of integrality constraint on each decision variable.
+
+        ``0`` : Continuous variable; no integrality constraint.
+
+        ``1`` : Integer variable; decision variable must be an integer
+        within `bounds`.
+
+        ``2`` : Semi-continuous variable; decision variable must be within
+        `bounds` or take value ``0``.
+
+        ``3`` : Semi-integer variable; decision variable must be an integer
+        within `bounds` or take value ``0``.
+
+        By default, all variables are continuous. This argument is currently
+        used only by the ``'highs'`` method and ignored otherwise.
 
     Returns
     -------
@@ -603,7 +619,12 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
         warning_message = "x0 is used only when method is 'revised simplex'. "
         warn(warning_message, OptimizeWarning)
 
-    lp = _LPProblem(c, A_ub, b_ub, A_eq, b_eq, bounds, x0)
+    if integrality and not meth == "highs":
+        warning_message = ("Only `method='highs'` supports integer "
+                           "constraints. Ignoring `integrality`.")
+        warn(warning_message, OptimizeWarning)
+
+    lp = _LPProblem(c, A_ub, b_ub, A_eq, b_eq, bounds, x0, integrality)
     lp, solver_options = _parse_linprog(lp, options, meth)
     tol = solver_options.get('tol', 1e-9)
 

--- a/scipy/optimize/_linprog_doc.py
+++ b/scipy/optimize/_linprog_doc.py
@@ -80,6 +80,21 @@ def _linprog_highs_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
         :ref:`'revised simplex' <optimize.linprog-revised_simplex>`, and
         :ref:`'simplex' <optimize.linprog-simplex>` (legacy)
         are also available.
+    integrality : 1-D array, optional
+        Indicates the type of integrality constraint on each decision variable.
+
+        ``0`` : Continuous variable; no integrality constraint.
+
+        ``1`` : Integer variable; decision variable must be an integer
+        within `bounds`.
+
+        ``2`` : Semi-continuous variable; decision variable must be within
+        `bounds` or take value ``0``.
+
+        ``3`` : Semi-integer variable; decision variable must be an integer
+        within `bounds` or take value ``0``.
+
+        By default, all variables are continuous.
 
     Options
     -------

--- a/scipy/optimize/_linprog_highs.py
+++ b/scipy/optimize/_linprog_highs.py
@@ -402,6 +402,10 @@ def _linprog_highs(lp, solver, time_limit=None, presolve=True,
     status, message = statuses[res['status']]
 
     x = np.array(res['x']) if 'x' in res else None
+    if np.any(x) and integrality is not None:
+        mask = (integrality == 1) | (integrality == 3)
+        x[mask] = np.round(x[mask])
+
     sol = {'x': x,
            'slack': slack,
            'con': con,

--- a/scipy/optimize/_linprog_highs.py
+++ b/scipy/optimize/_linprog_highs.py
@@ -84,7 +84,6 @@ def _linprog_highs(lp, solver, time_limit=None, presolve=True,
                    primal_feasibility_tolerance=None,
                    ipm_optimality_tolerance=None,
                    simplex_dual_edge_weight_strategy=None,
-                   integrality=None,
                    **unknown_options):
     r"""
     Solve the following linear programming problem using one of the HiGHS
@@ -325,7 +324,7 @@ def _linprog_highs(lp, solver, time_limit=None, presolve=True,
         ),
     }
 
-    c, A_ub, b_ub, A_eq, b_eq, bounds, x0 = lp
+    c, A_ub, b_ub, A_eq, b_eq, bounds, x0, integrality = lp
 
     lb, ub = bounds.T.copy()  # separate bounds, copy->C-cntgs
     # highs_wrapper solves LHS <= A*x <= RHS, not equality constraints

--- a/scipy/optimize/_linprog_util.py
+++ b/scipy/optimize/_linprog_util.py
@@ -12,7 +12,8 @@ from scipy.optimize._remove_redundancy import (
     )
 from collections import namedtuple
 
-_LPProblem = namedtuple('_LPProblem', 'c A_ub b_ub A_eq b_eq bounds x0')
+_LPProblem = namedtuple('_LPProblem',
+                        'c A_ub b_ub A_eq b_eq bounds x0 integrality')
 _LPProblem.__new__.__defaults__ = (None,) * 6  # make c the only required arg
 _LPProblem.__doc__ = \
     """ Represents a linear-programming problem.
@@ -258,7 +259,7 @@ def _clean_inputs(lp):
             basic feasible solution.
 
     """
-    c, A_ub, b_ub, A_eq, b_eq, bounds, x0 = lp
+    c, A_ub, b_ub, A_eq, b_eq, bounds, x0, integrality = lp
 
     if c is None:
         raise TypeError
@@ -448,7 +449,7 @@ def _clean_inputs(lp):
     i_none = np.isnan(bounds_clean[:, 1])
     bounds_clean[i_none, 1] = np.inf
 
-    return _LPProblem(c, A_ub, b_ub, A_eq, b_eq, bounds_clean, x0)
+    return _LPProblem(c, A_ub, b_ub, A_eq, b_eq, bounds_clean, x0, integrality)
 
 
 def _presolve(lp, rr, rr_method, tol=1e-9):
@@ -572,7 +573,7 @@ def _presolve(lp, rr, rr_method, tol=1e-9):
     #  * loop presolve until no additional changes are made
     #  * implement additional efficiency improvements in redundancy removal [2]
 
-    c, A_ub, b_ub, A_eq, b_eq, bounds, x0 = lp
+    c, A_ub, b_ub, A_eq, b_eq, bounds, x0, _ = lp
 
     revstack = []               # record of variables eliminated from problem
     # constant term in cost function may be added if variables are eliminated
@@ -1089,7 +1090,7 @@ def _get_Abc(lp, c0):
            programming." Athena Scientific 1 (1997): 997.
 
     """
-    c, A_ub, b_ub, A_eq, b_eq, bounds, x0 = lp
+    c, A_ub, b_ub, A_eq, b_eq, bounds, x0, integrality = lp
 
     if sps.issparse(A_eq):
         sparse = True
@@ -1355,7 +1356,8 @@ def _postsolve(x, postsolve_args, complete=False):
     # note that all the inputs are the ORIGINAL, unmodified versions
     # no rows, columns have been removed
 
-    (c, A_ub, b_ub, A_eq, b_eq, bounds, x0), revstack, C, b_scale = postsolve_args
+    c, A_ub, b_ub, A_eq, b_eq, bounds, x0, integrality = postsolve_args[0]
+    revstack, C, b_scale = postsolve_args[1:]
 
     x = _unscale(x, C, b_scale)
 

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -401,23 +401,21 @@ class LinprogCommonTests:
 
     def test_integrality_without_highs(self):
         # ensure that using `integrality` parameter without `method='highs'`
-        # raises warning.
-        # source: https://www.mathworks.com/help/optim/ug/intlinprog.html
-        A_ub = np.array([[1, 1, 1]])
-        b_ub = np.array([7])
-        A_eq = np.array([[4, 2, 1]])
-        b_eq = np.array([12])
-        c = np.array([-3, -2, -1])
+        # raises warning and produces correct solution to relaxed problem
+        # source: https://en.wikipedia.org/wiki/Integer_programming#Example
+        A_ub = np.array([[-1, 1], [3, 2], [2, 3]])
+        b_ub = np.array([1, 12, 12])
+        c = -np.array([0, 1])
 
-        bounds = [(0, np.inf), (0, np.inf), (0, 1)]
-        integrality = [0, 1, 0]
+        bounds = [(0, np.inf)] * len(c)
+        integrality = [1] * len(c)
 
         with np.testing.assert_warns(OptimizeWarning):
-            res = linprog(c=c, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq,
-                          bounds=bounds, method=self.method,
-                          integrality=integrality)
+            res = linprog(c=c, A_ub=A_ub, b_ub=b_ub, bounds=bounds,
+                          method=self.method, integrality=integrality)
 
-        np.testing.assert_allclose(res.fun, -12)
+        np.testing.assert_allclose(res.x, [1.8, 2.8])
+        np.testing.assert_allclose(res.fun, -2.8)
 
     def test_invalid_inputs(self):
 

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -2134,7 +2134,9 @@ class TestLinprogHiGHSMIP():
 
     def test_mip1(self):
         # solve non-relaxed magic square problem (finally!)
-        n = 3
+        # also check that values are all integers - they don't always
+        # come out of HiGHS that way
+        n = 4
         A, b, c, numbers, M = magic_square(n)
         bounds = [(0, 1)] * len(c)
         integrality = [1] * len(c)
@@ -2142,13 +2144,14 @@ class TestLinprogHiGHSMIP():
         res = linprog(c=c*0, A_eq=A, b_eq=b, bounds=bounds,
                       method=self.method, integrality=integrality)
 
-        x = np.round(res.x).astype('int')
-        s = (numbers.flatten()*x).reshape(n**2,n,n)
+        s = (numbers.flatten() * res.x).reshape(n**2, n, n)
         square = np.sum(s, axis=0)
         np.testing.assert_allclose(square.sum(axis=0), M)
         np.testing.assert_allclose(square.sum(axis=1), M)
         np.testing.assert_allclose(np.diag(square).sum(), M)
         np.testing.assert_allclose(np.diag(square[:, ::-1]).sum(), M)
+
+        np.testing.assert_equal(res.x, np.round(res.x))
 
     def test_mip2(self):
         # solve MIP with inequality constraints and all integer constraints


### PR DESCRIPTION
#### Reference issue
gh-28

#### What does this implement/fix?
Makes `integrality` a parameter instead of an option. Adds `integrality` documentation and tests.

#### Additional information
I think HiGHS should ensure that DVs marked as integral are exactly integral. I added a patch for that here, but maybe it's something that should be done upstream.